### PR TITLE
Remove certain fonts to eliminate rendering error

### DIFF
--- a/public_html/index.php
+++ b/public_html/index.php
@@ -32,7 +32,7 @@ $formats = [
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="preconnect" href="//fonts.gstatic.com">
 	<link rel="shortcut icon" type="image/png" href="/favicon.png">
-	<link href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&amp;subset=cyrillic,greek" rel="stylesheet" media="none" onload="if(media!='all')media='all'">
+	<link href="https://fonts.googleapis.com/css2?family=Noto+Serif:ital,wght@0,400;0,700;1,400;1,700&family=Ubuntu+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet" media="none" onload="if(media!='all')media='all'">
 
 <?php if (defined('USE_MINIFICATION') && USE_MINIFICATION): ?>
 	<link rel="stylesheet" href="/dist/css/style.min.css?<?php include 'dist/css/style.min.css.md5'; ?>">
@@ -42,6 +42,8 @@ $formats = [
 	<link rel="stylesheet" href="/lib/highlight.js/solarized-light.css">
 <?php endif; ?>
 
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link rel="preconnect" href="//i.upmath.me" crossorigin>
 	<link rel="prefetch" href="/i/latex.jpg" as=image>
 </head>

--- a/public_html/src/css/editor.css
+++ b/public_html/src/css/editor.css
@@ -217,7 +217,7 @@ div.header {
 }
 
 .source, .ldt pre.ldt-pre, .ldt textarea {
-	font-family: Consolas, "Liberation Mono", "Ubuntu Mono", monospace; #-menlo, monaco
+	font-family: Consolas, "Liberation Mono", "Ubuntu Mono", monospace;
 	font-size: 14px;
 	line-height: 21px;
 }

--- a/public_html/src/css/editor.css
+++ b/public_html/src/css/editor.css
@@ -217,7 +217,7 @@ div.header {
 }
 
 .source, .ldt pre.ldt-pre, .ldt textarea {
-	font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+	font-family: Consolas, "Liberation Mono", "Ubuntu Mono", monospace; #-menlo, monaco
 	font-size: 14px;
 	line-height: 21px;
 }


### PR DESCRIPTION
I've noticed a text rendering error while using upmath.me on an iPad, and only recently on my desktop machine. 

![Text rendering "shadow" error](https://user-images.githubusercontent.com/18331588/124859873-9eeae680-df7e-11eb-920c-1df561404bff.png)

This only occured after I installed the `Menlo` font (default monospaced font on iPadOS/MacOS), which has different widths for weights 400 and 700. Since the `<texteditor>` element does not render certain strings as bold, this causes misalignment between the actual editor element and the preview overlay on top of it.

![Misaligned text caused by the bold glitch](https://user-images.githubusercontent.com/18331588/124860334-7a433e80-df7f-11eb-85ed-ec2e4548af27.png)

You can see this here, where my cursor is at the end of the gray editable text, while the blue preview extends farther.

![Misaligned text glitch resolved using a non-variable width font](https://user-images.githubusercontent.com/18331588/124860470-b5de0880-df7f-11eb-950c-e7956d00ef93.png)

This can be resolved by disabling the certain fonts which have variable widths. 

---

My resolution for the issue is removing Menlo, Monaco, and Courier New from the system font stack, and replacing them with `Consolas, "Liberation Mono", "Ubuntu Mono", monospace`. Consolas will resolve on modern Windows machines, Liberation Mono is the monospaced default on many GNU/Linux distrobutions, and "Ubuntu Mono" can be loaded from Google Fonts for MacOS/other machines which do not have these other default fonts. All of these fonts do not vary in width when changing widths, eliminating this issue.

Please let me know what you think! 